### PR TITLE
fix: correct spelling mistakes in migrations

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-    //    Schema::defaultStringLenght(191);
+        Schema::defaultStringLength(191);
     }
 
     /**

--- a/database/migrations/2018_11_15_233230_create_departments_table.php
+++ b/database/migrations/2018_11_15_233230_create_departments_table.php
@@ -13,11 +13,11 @@ class CreateDepartmentsTable extends Migration
      */
     public function up()
     {
-        Schema::create('deprtments', function (Blueprint $table) {
+        Schema::create('departments', function (Blueprint $table) {
             $table->increments('id');
             $table->char('name',20);
             $table->integer('class');
-            $table->integer('num_strudents')->nullable();
+            $table->integer('num_students')->nullable();
         });
     }
 
@@ -28,6 +28,6 @@ class CreateDepartmentsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('classes');
+        Schema::dropIfExists('departments');
     }
 }

--- a/database/migrations/2018_11_15_233450_create_students_table.php
+++ b/database/migrations/2018_11_15_233450_create_students_table.php
@@ -18,12 +18,13 @@ class CreateStudentsTable extends Migration
             $table->char('f_name',20);
             $table->char('l_name',20);
             $table->enum('gender',['male','female']);
-            $table->string(' featured');
+            $table->string('featured');
             $table->smallInteger('grade_maths')->unsigned()->nullable();
             $table->smallInteger('grade_literature')->unsigned()->nullable();
             $table->smallInteger('grade_biology')->unsigned()->nullable();
-            $table->foreign('deprtment_id')
-                ->references('id')->on('deprtments')
+            $table->unsignedInteger('department_id');
+            $table->foreign('department_id')
+                ->references('id')->on('departments')
                 ->onDelete('cascade');
         });
     }


### PR DESCRIPTION
Don't forget
```
composer dumpautoload
```
and to drop the db (fastest) and recreate it since your migrations were broken and it can sometimes mess with `php artisan migrate:refresh`.